### PR TITLE
Added new class for simplifying OPCUA requests

### DIFF
--- a/BoxwriterInterop.Tests/GetUserElementsRequestHandlerTests.cs
+++ b/BoxwriterInterop.Tests/GetUserElementsRequestHandlerTests.cs
@@ -1,5 +1,6 @@
 namespace BoxwriterResmarkInterop.Tests;
 
+using BoxwriterResmarkInterop.OPCUA;
 using Handlers;
 
 using Interfaces;

--- a/BoxwriterInterop.Tests/GetUserElementsRequestHandlerTests.cs
+++ b/BoxwriterInterop.Tests/GetUserElementsRequestHandlerTests.cs
@@ -1,11 +1,10 @@
 namespace BoxwriterResmarkInterop.Tests;
 
-using BoxwriterResmarkInterop.OPCUA;
+using OPCUA;
+
 using Handlers;
 
 using Interfaces;
-
-using OPCUA;
 
 using Requests;
 

--- a/BoxwriterInterop.Tests/GetUserElementsRequestHandlerTests.cs
+++ b/BoxwriterInterop.Tests/GetUserElementsRequestHandlerTests.cs
@@ -24,10 +24,8 @@ public class GetUserElementsRequestHandlerTests
         _mocker
             .GetMock<IOPCUAService>()
             .Setup(service => service.CallMethodAsync(
-                It.IsAny<string>(),
-                It.Is<string>(s => s == OPCUAMethods.GetMessageVariableData.ToString()),
-                It.IsAny<CancellationToken>(),
-                It.Is<int>(i => i == TaskNumber)))
+                It.Is<OPCUARequest>(request => request.Method == OPCUAMethods.GetMessageVariableData),
+                It.IsAny<CancellationToken>()))
             .Returns(() =>
             {
                 var serializer = new XmlSerializer<Dictionary<string, string>>();
@@ -56,10 +54,8 @@ public class GetUserElementsRequestHandlerTests
         _mocker
             .GetMock<IOPCUAService>()
             .Setup(service => service.CallMethodAsync(
-                It.IsAny<string>(),
-                It.Is<string>(s => s == OPCUAMethods.GetMessageVariableData.ToString()),
-                It.IsAny<CancellationToken>(),
-                It.Is<int>(i => i == TaskNumber)))
+                It.Is<OPCUARequest>(request => request.Method == OPCUAMethods.GetMessageVariableData),
+                It.IsAny<CancellationToken>()))
             .Returns(() => Task.FromResult(new CallMethodResult
             {
                 OutputArguments = new[] { new Variant(0), new Variant(string.Empty) }

--- a/BoxwriterInterop.Tests/SetUserElementsRequestHandlerTests.cs
+++ b/BoxwriterInterop.Tests/SetUserElementsRequestHandlerTests.cs
@@ -1,5 +1,6 @@
 namespace BoxwriterResmarkInterop.Tests;
 
+using BoxwriterResmarkInterop.OPCUA;
 using Handlers;
 
 using Interfaces;

--- a/BoxwriterInterop.Tests/SetUserElementsRequestHandlerTests.cs
+++ b/BoxwriterInterop.Tests/SetUserElementsRequestHandlerTests.cs
@@ -38,11 +38,8 @@ public class SetUserElementsRequestHandlerTests
         _mocker
             .GetMock<IOPCUAService>()
             .Setup(service => service.CallMethodAsync(
-                It.IsAny<string>(),
-                It.Is<string>(s => s == OPCUAMethods.SetMessageVariableData.ToString()),
-                It.IsAny<CancellationToken>(),
-                It.Is<int>(i => i == TaskNumber),
-                It.IsAny<string>()))
+                It.Is<OPCUARequest>(request => request.Method == OPCUAMethods.SetMessageVariableData),
+                It.IsAny<CancellationToken>()))
             .Returns(() =>
                 Task.FromResult(new CallMethodResult { OutputArguments = new[] { new Variant(0) } }));
 

--- a/BoxwriterInterop.Tests/SetUserElementsRequestHandlerTests.cs
+++ b/BoxwriterInterop.Tests/SetUserElementsRequestHandlerTests.cs
@@ -1,11 +1,10 @@
 namespace BoxwriterResmarkInterop.Tests;
 
-using BoxwriterResmarkInterop.OPCUA;
+using OPCUA;
+
 using Handlers;
 
 using Interfaces;
-
-using OPCUA;
 
 using Requests;
 

--- a/BoxwriterResmarkInterop/Handlers/GetTasksRequestHandler.cs
+++ b/BoxwriterResmarkInterop/Handlers/GetTasksRequestHandler.cs
@@ -27,8 +27,13 @@ public class GetTasksRequestHandler : IRequestHandler<GetTasksRequest, StringRes
     {
         var printerId = request.Data.ExtractPrinterId();
 
-        var response = await _opcuaService.CallMethodAsync(printerId, OPCUAMethods.GetStoredMessageList.ToString(),
-            cancellationToken).ConfigureAwait(false);
+        var opcuaRequest = new OPCUARequest
+        {
+            PrinterId = printerId,
+            Method = OPCUAMethods.GetStoredMessageList
+        };
+
+        var response = await _opcuaService.CallMethodAsync(opcuaRequest, cancellationToken).ConfigureAwait(false);
 
         return new StringResponse(GetTasks, printerId, GetResponseData(response));
     }

--- a/BoxwriterResmarkInterop/Handlers/GetUserElementsRequestHandler.cs
+++ b/BoxwriterResmarkInterop/Handlers/GetUserElementsRequestHandler.cs
@@ -31,8 +31,14 @@ public class GetUserElementsRequestHandler : IRequestHandler<GetUserElementsRequ
     {
         var printerId = request.Data.ExtractPrinterId();
 
-        var response = await _opcuaService.CallMethodAsync(printerId, OPCUAMethods.GetMessageVariableData.ToString(),
-            cancellationToken, TaskNumber).ConfigureAwait(false);
+        var opcuaRequest = new OPCUARequest
+        {
+            PrinterId = printerId,
+            Method = OPCUAMethods.GetMessageVariableData,
+            TaskNumber = TaskNumber
+        };
+
+        var response = await _opcuaService.CallMethodAsync(opcuaRequest, cancellationToken).ConfigureAwait(false);
 
         return new StringResponse(GetUserElements, printerId, GetResponseData(response));
     }

--- a/BoxwriterResmarkInterop/Handlers/IdleTaskCommandHandler.cs
+++ b/BoxwriterResmarkInterop/Handlers/IdleTaskCommandHandler.cs
@@ -1,7 +1,5 @@
 ﻿namespace BoxwriterResmarkInterop.Handlers;
 
-using Exceptions;
-
 using Extensions;
 
 using Interfaces;
@@ -29,8 +27,14 @@ public class IdleTaskCommandHandler : IRequestHandler<IdleTaskRequest, StringRes
     {
         var printerId = request.Data.ExtractPrinterId();
 
-        var response = await _opcuaService.CallMethodAsync(printerId, OPCUAMethods.StopPrinting.ToString(), cancellationToken, TaskNumber)
-            .ConfigureAwait(false);
+        var opcuaRequest = new OPCUARequest
+        {
+            PrinterId = printerId,
+            Method = OPCUAMethods.StopPrinting,
+            TaskNumber = TaskNumber
+        };
+
+        var response = await _opcuaService.CallMethodAsync(opcuaRequest, cancellationToken).ConfigureAwait(false);
 
         return new StringResponse(IdleTask, printerId, GetResponseData(response));
     }

--- a/BoxwriterResmarkInterop/Handlers/LoadTaskCommandHandler.cs
+++ b/BoxwriterResmarkInterop/Handlers/LoadTaskCommandHandler.cs
@@ -1,7 +1,5 @@
 ﻿namespace BoxwriterResmarkInterop.Handlers;
 
-using Exceptions;
-
 using Extensions;
 
 using Interfaces;
@@ -30,7 +28,14 @@ public class LoadTaskCommandHandler : IRequestHandler<LoadTaskRequest, StringRes
         var printerId = request.Data.ExtractPrinterId();
         var messageName = request.Data.ExtractAdditionalParameter();
 
-        var response = await _opcuaService.CallMethodAsync(printerId, OPCUAMethods.PrintStoredMessage.ToString(), cancellationToken, messageName);
+        var opcuaRequest = new OPCUARequest
+        {
+            PrinterId = printerId,
+            Method = OPCUAMethods.PrintStoredMessage,
+            InputArgs = new object[] { messageName }
+        };
+
+        var response = await _opcuaService.CallMethodAsync(opcuaRequest, cancellationToken).ConfigureAwait(false);
 
         return new StringResponse(LoadTask, printerId, GetResponseData(response));
     }

--- a/BoxwriterResmarkInterop/Handlers/ResumeTaskCommandHandler.cs
+++ b/BoxwriterResmarkInterop/Handlers/ResumeTaskCommandHandler.cs
@@ -1,7 +1,5 @@
 ﻿namespace BoxwriterResmarkInterop.Handlers;
 
-using Exceptions;
-
 using Extensions;
 
 using Interfaces;
@@ -29,8 +27,14 @@ public class ResumeTaskCommandHandler : IRequestHandler<ResumeTaskRequest, Strin
     {
         var printerId = request.Data.ExtractPrinterId();
 
-        var response = await _opcuaService.CallMethodAsync(printerId, OPCUAMethods.ResumePrinting.ToString(), cancellationToken, TaskNumber)
-            .ConfigureAwait(false);
+        var opcuaRequest = new OPCUARequest
+        {
+            PrinterId = printerId,
+            Method = OPCUAMethods.ResumePrinting,
+            TaskNumber = TaskNumber
+        };
+
+        var response = await _opcuaService.CallMethodAsync(opcuaRequest, cancellationToken).ConfigureAwait(false);
 
         return new StringResponse(ResumeTask, printerId, GetResponseData(response));
     }

--- a/BoxwriterResmarkInterop/Handlers/StartTaskCommandHandler.cs
+++ b/BoxwriterResmarkInterop/Handlers/StartTaskCommandHandler.cs
@@ -1,7 +1,5 @@
 namespace BoxwriterResmarkInterop.Handlers;
 
-using Exceptions;
-
 using Extensions;
 
 using Interfaces;
@@ -29,9 +27,14 @@ public class StartTaskCommandHandler : IRequestHandler<StartTaskRequest, StringR
     {
         var printerId = request.Data.ExtractPrinterId();
 
-        var response = await _opcuaService
-            .CallMethodAsync(printerId, OPCUAMethods.ResumePrinting.ToString(), cancellationToken, TaskNumber)
-            .ConfigureAwait(false);
+        var opcuaRequest = new OPCUARequest
+        {
+            PrinterId = printerId,
+            Method = OPCUAMethods.ResumePrinting,
+            TaskNumber = TaskNumber
+        };
+
+        var response = await _opcuaService.CallMethodAsync(opcuaRequest, cancellationToken).ConfigureAwait(false);
 
         return new StringResponse(StartTask, printerId, GetResponseData(response));
     }

--- a/BoxwriterResmarkInterop/Interfaces/IOPCUAService.cs
+++ b/BoxwriterResmarkInterop/Interfaces/IOPCUAService.cs
@@ -1,25 +1,34 @@
 ﻿namespace BoxwriterResmarkInterop.Interfaces;
 
+using OPCUA;
 using Workstation.ServiceModel.Ua;
+
+public class OPCUARequest
+{
+    public string PrinterId { get; init; } = string.Empty;
+    public OPCUAMethods Method { get; init; }
+    public int? TaskNumber { get; init; }
+    public object[]? InputArgs { get; init; }
+
+    public Variant[] GetArgsAsVariant()
+    {
+        var args = new List<Variant>();
+
+        if (TaskNumber.HasValue)
+        {
+            args.Add(new Variant(TaskNumber.Value));
+        }
+
+        if (InputArgs != null)
+        {
+            args.AddRange(InputArgs.Select(arg => new Variant(arg)));
+        }
+
+        return args.ToArray();
+    }
+}
 
 public interface IOPCUAService
 {
-    Task<CallMethodResult> CallMethodAsync(
-        string printerId,
-        string method,
-        CancellationToken stoppingToken,
-        params string[] inputArgs);
-
-    Task<CallMethodResult> CallMethodAsync(
-        string printerId,
-        string method,
-        CancellationToken stoppingToken,
-        int taskNumber);
-
-    Task<CallMethodResult> CallMethodAsync(
-        string printerId,
-        string method,
-        CancellationToken stoppingToken,
-        int taskNumber,
-        string inputArgs);
+    Task<CallMethodResult> CallMethodAsync(OPCUARequest request, CancellationToken stoppingToken);
 }

--- a/BoxwriterResmarkInterop/Interfaces/IOPCUAService.cs
+++ b/BoxwriterResmarkInterop/Interfaces/IOPCUAService.cs
@@ -1,5 +1,6 @@
 ﻿namespace BoxwriterResmarkInterop.Interfaces;
 
+using BoxwriterResmarkInterop.OPCUA;
 using Workstation.ServiceModel.Ua;
 
 public interface IOPCUAService

--- a/BoxwriterResmarkInterop/Interfaces/IOPCUAService.cs
+++ b/BoxwriterResmarkInterop/Interfaces/IOPCUAService.cs
@@ -1,32 +1,6 @@
 ﻿namespace BoxwriterResmarkInterop.Interfaces;
 
-using OPCUA;
 using Workstation.ServiceModel.Ua;
-
-public class OPCUARequest
-{
-    public string PrinterId { get; init; } = string.Empty;
-    public OPCUAMethods Method { get; init; }
-    public int? TaskNumber { get; init; }
-    public object[]? InputArgs { get; init; }
-
-    public Variant[] GetArgsAsVariant()
-    {
-        var args = new List<Variant>();
-
-        if (TaskNumber.HasValue)
-        {
-            args.Add(new Variant(TaskNumber.Value));
-        }
-
-        if (InputArgs != null)
-        {
-            args.AddRange(InputArgs.Select(arg => new Variant(arg)));
-        }
-
-        return args.ToArray();
-    }
-}
 
 public interface IOPCUAService
 {

--- a/BoxwriterResmarkInterop/Interfaces/OPCUARequest.cs
+++ b/BoxwriterResmarkInterop/Interfaces/OPCUARequest.cs
@@ -1,0 +1,30 @@
+﻿namespace BoxwriterResmarkInterop.Interfaces;
+
+using OPCUA;
+
+using Workstation.ServiceModel.Ua;
+
+public class OPCUARequest
+{
+    public string PrinterId { get; init; } = string.Empty;
+    public OPCUAMethods Method { get; init; }
+    public int? TaskNumber { get; init; }
+    public object[]? InputArgs { get; init; }
+
+    public Variant[] GetArgsAsVariant()
+    {
+        var args = new List<Variant>();
+
+        if (TaskNumber.HasValue)
+        {
+            args.Add(new Variant(TaskNumber.Value));
+        }
+
+        if (InputArgs != null)
+        {
+            args.AddRange(InputArgs.Select(arg => new Variant(arg)));
+        }
+
+        return args.ToArray();
+    }
+}

--- a/BoxwriterResmarkInterop/OPCUA/OPCUARequest.cs
+++ b/BoxwriterResmarkInterop/OPCUA/OPCUARequest.cs
@@ -1,6 +1,4 @@
-﻿namespace BoxwriterResmarkInterop.Interfaces;
-
-using OPCUA;
+﻿namespace BoxwriterResmarkInterop.OPCUA;
 
 using Workstation.ServiceModel.Ua;
 


### PR DESCRIPTION
Adds a new class to the project that simplifies OPCUA request API by encapsulating the variant-type logic into a single class rather than using method parameters.

>Clean Code recommends keeping the number of arguments in a function small, ideally no more than three or four. This is because having many arguments can make it difficult to understand, reason about, and test the function. Grouping related arguments into a single object or data structure can help simplify the function interface and make it easier to understand the expected input.